### PR TITLE
Defined file permissions for apt config file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,3 +5,4 @@
     dest: /etc/apt/apt.conf.d/80-vagrant
     owner: root
     group: root
+    mode: 'u=rw,go=r'


### PR DESCRIPTION
While the defaults work it's best to be explicit.
