### PR TITLE
Added ansible_managed header to template file

### DIFF
--- a/templates/apt.conf.j2
+++ b/templates/apt.conf.j2
@@ -1,3 +1,5 @@
+// {{ ansible_managed }}
+
 {% if apt_preserve_cache %}
 APT::Archives::MaxAge "0";
 APT::Archives::MinAge "0";


### PR DESCRIPTION
This is useful to tell users that a file has been placed by Ansible and manual changes are likely to be overwritten.
