### PR TITLE
Adopted yes|no convention for booleans

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ are shown below):
 apt_config_filename: '80-vagrant'
 
 # Whether the cache of DEB files should be preserved or cleaned
-apt_preserve_cache: false
+apt_preserve_cache: no
 
 # Max age (in days) of DEB files to keep when cleaning cache
 apt_archives_maxage: null
@@ -43,7 +43,7 @@ Example Playbook
 ```yaml
 - hosts: servers
   roles:
-     - { role: gantsign.apt, apt_preserve_cache: true }
+     - { role: gantsign.apt, apt_preserve_cache: yes }
 ```
 
 Development & Testing

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 apt_config_filename: '80-vagrant'
 
 # Whether the cache of DEB files should be preserved or cleaned
-apt_preserve_cache: false
+apt_preserve_cache: no
 
 # Max age (in days) of DEB files to keep when cleaning cache
 apt_archives_maxage: null

--- a/templates/apt.conf.j2
+++ b/templates/apt.conf.j2
@@ -1,6 +1,6 @@
 // {{ ansible_managed }}
 
-{% if apt_preserve_cache %}
+{% if apt_preserve_cache | bool %}
 APT::Archives::MaxAge "0";
 APT::Archives::MinAge "0";
 APT::Archives::MaxSize "0";


### PR DESCRIPTION
Ansible supports `true|false` and `yes|no` (with varying case) for boolean values; the Ansible documentation is wildly inconsistent on which it uses, so it's easy to end up with a mixture.

It's better to be consistent, so `yes|no` is now the convention for all Ansible roles written by GantSign.
