### PR TITLE
Added license shield to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Ansible Role: APT
 
 [![Build Status](https://travis-ci.org/gantsign/ansible-role-apt.svg?branch=master)](https://travis-ci.org/gantsign/ansible-role-apt)
 [![Ansible Galaxy](https://img.shields.io/badge/ansible--galaxy-gantsign.apt-blue.svg)](https://galaxy.ansible.com/gantsign/apt)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/gantsign/ansible-role-apt/master/LICENSE)
 
 Role to configure the APT package manager. Currently limited to controlling the
 properties that affect the cleaning of the DEB files (typically by the APT cron


### PR DESCRIPTION
So users can see the type of license at the top of the page.
