### PR TITLE
Specify hosts to testinfa via python

### DIFF
--- a/molecule.yml
+++ b/molecule.yml
@@ -7,6 +7,3 @@ docker:
   - name: ansible-role-apt-01
     image: ubuntu
     image_version: '16.04'
-
-testinfra:
-  hosts: 'ansible-role-apt-01'

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -1,5 +1,10 @@
 import pytest
 
+from testinfra.utils.ansible_runner import AnsibleRunner
+
+testinfra_hosts = AnsibleRunner('.molecule/ansible_inventory').get_hosts('all')
+
+
 def test_apt_config_file_permissions(File):
     conf = File('/etc/apt/apt.conf.d/80-test')
 


### PR DESCRIPTION
Was specifying hosts via molecule.yml file. The new approach is dynamic and avoids repeating configuration information.
