### PR TITLE
Parameterized test syntax improvement

### DIFF
--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -16,9 +16,9 @@ def test_apt_config_file_permissions(File):
 
 
 @pytest.mark.parametrize('param', [
-    ('APT::Archives::MaxAge "81";'),
-    ('APT::Archives::MinAge "82";'),
-    ('APT::Archives::MaxSize "83";')
+    'APT::Archives::MaxAge "81";',
+    'APT::Archives::MinAge "82";',
+    'APT::Archives::MaxSize "83";'
 ])
 def test_apt_config_file(File, param):
     conf = File('/etc/apt/apt.conf.d/80-test')


### PR DESCRIPTION
Use simple array if there only a single param.
