### PR TITLE
Switched to single quoted strings in YAML

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
   become: yes
   template:
     src: apt.conf.j2
-    dest: "/etc/apt/apt.conf.d/{{ apt_config_filename }}"
+    dest: '/etc/apt/apt.conf.d/{{ apt_config_filename }}'
     owner: root
     group: root
     mode: 'u=rw,go=r'


### PR DESCRIPTION
Avoid unnecessary escape sequence processing.