### PR TITLE
Changed example role to pure YAML syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Example Playbook
 ```yaml
 - hosts: servers
   roles:
-     - { role: gantsign.apt, apt_preserve_cache: yes }
+    - role: gantsign.apt
+      apt_preserve_cache: yes
 ```
 
 More Roles From GantSign


### PR DESCRIPTION
Using the hybrid YAML/JSON syntax is potentially confusing to new users as it's not clear whether this peculiar syntax is a requirement or not.