### PR TITLE
Dropped documented support for Ubuntu Wily

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,7 +8,6 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - trusty
-        - wily
         - xenial
   galaxy_tags:
     - apt


### PR DESCRIPTION
It's no longer a supported Ubuntu version.